### PR TITLE
add -u option to show users

### DIFF
--- a/fatrace.8
+++ b/fatrace.8
@@ -89,6 +89,10 @@ human readable hour:minute:second.microsecond; when given twice, the timestamp
 is printed as seconds/microseconds since the epoch.
 
 .TP
+.B \-u\fR, \fB\-\-user
+Add process user information to events, formatted as "[uid:gid]".
+
+.TP
 .B \-p \fIPID\fR, \fB\-\-ignore\-pid=\fIPID
 Ignore events for this process ID. Can be specified multiple times.
 

--- a/tests/fatrace-user
+++ b/tests/fatrace-user
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -euC
+
+USER=nobody
+ROOT_LOG="\\[0:0\\]"
+USER_LOG="\\[$(id -u $USER):$(id -g $USER)\\]"
+
+mkdir -m 777 tmp
+trap "rm -rf tmp" EXIT INT QUIT PIPE
+
+LOG="$AUTOPKGTEST_TMP/fatrace.log"
+echo "starting fatrace..."
+fatrace --current-mount --user -s 2 -o $LOG &
+sleep 1
+
+echo "read a file as root ..."
+head NEWS > /dev/null
+
+echo "read a file as user ..."
+runuser -u $USER tail NEWS > /dev/null
+
+echo "create/remove a file as root..."
+TEST_FILE_ROOT=testroot.txt
+touch "$TEST_FILE_ROOT"
+rm "$TEST_FILE_ROOT"
+
+echo "create/remove a file as usr..."
+TEST_FILE_USER=tmp/test$USER.txt
+runuser -u $USER touch "$TEST_FILE_USER"
+runuser -u $USER rm "$TEST_FILE_USER"
+
+echo "waiting for fatrace..."
+wait
+
+echo "checking log..."
+RC=0
+check_log() {
+    if ! grep -q "$1" $LOG; then
+        echo "$1 not found in log" >&2
+        ((RC=RC+1))
+    fi
+}
+
+# accessing the NEWS file as root
+check_log "^head([0-9]*) $ROOT_LOG: RC\?O\? \+$(pwd)/NEWS$"
+
+# accessing the NEWS file as user
+check_log "^tail([0-9]*) $USER_LOG: RC\?O\? \+$(pwd)/NEWS$"
+
+# file creation as root
+TEST_FILE_ROOT=$(realpath "$TEST_FILE_ROOT")
+check_log "^touch([0-9]*) $ROOT_LOG: C\?W\?O \+$TEST_FILE_ROOT"
+
+TEST_FILE_USER=$(realpath "$TEST_FILE_USER")
+check_log "^touch([0-9]*) $USER_LOG: C\?W\?O \+$TEST_FILE_USER"
+
+if [ $RC -ne 0 ]; then
+   echo "$RC checks failed -- log:" >&2
+   echo "===================" >&2
+   cat $LOG >&2
+   echo "===================" >&2
+fi
+
+exit $RC

--- a/tests/run
+++ b/tests/run
@@ -4,7 +4,7 @@ set -eu
 MYDIR=$(dirname $(readlink -f "$0"))
 export PATH=$(pwd):$PATH
 
-for t in fatrace fatrace-currentmount fatrace-btrfs; do
+for t in fatrace fatrace-currentmount fatrace-btrfs fatrace-user; do
     export AUTOPKGTEST_TMP=$(mktemp -d)
     echo "===== $t ===="
     "$MYDIR"/$t


### PR DESCRIPTION
I've taken a shot at adding a new command line option `-u` which shows the process owner's `uid:gid` in a new column for each output. It does this by checking the output of `stat()` on the file descriptor in `/proc`. This has the same possible issue as printing the process name, where there's a race condition where the file might disappear from `/proc` before `fatrace` reads it. In this case, the output is `-:-` rather than e.g. `1000:1000`.