### PR TITLE
Truncate overly long --command matches

### DIFF
--- a/tests/fatrace-comm
+++ b/tests/fatrace-comm
@@ -5,7 +5,7 @@ mkdir -m 777 tmp
 trap "rm -rf tmp" EXIT INT QUIT PIPE
 
 LOG="$AUTOPKGTEST_TMP/fatrace.log"
-echo "starting fatrace..."
+echo "starting fatrace --command touch..."
 fatrace --current-mount --command touch -s 2 -o $LOG &
 sleep 1
 
@@ -31,6 +31,18 @@ if grep -Eq "notme|^dd" $LOG; then
     echo "notme found in log" >&2
     ((RC=RC+1))
 fi
+
+# exceeds TASK_COMM_LEN
+rm $LOG
+cp $(which touch) tmp/VeryLongTouchCommand
+echo "starting fatrace --command VeryLongTouchCommand..."
+fatrace --current-mount --command VeryLongTouchCommand -s 2 -o $LOG &
+sleep 1
+tmp/VeryLongTouchCommand tmp/hello.txt
+echo "waiting for fatrace..."
+wait
+
+check_log "^VeryLongTouchCo([0-9]*).*hello.txt$"
 
 if [ $RC -ne 0 ]; then
    echo "$RC checks failed -- log:" >&2

--- a/tests/fatrace-comm
+++ b/tests/fatrace-comm
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -euC
+
+mkdir -m 777 tmp
+trap "rm -rf tmp" EXIT INT QUIT PIPE
+
+LOG="$AUTOPKGTEST_TMP/fatrace.log"
+echo "starting fatrace..."
+fatrace --current-mount --command touch -s 2 -o $LOG &
+sleep 1
+
+echo "create files with different programs"
+touch tmp/includeme
+dd if=/dev/zero of=tmp/notme bs=1 count=1
+
+echo "waiting for fatrace..."
+wait
+
+echo "checking log..."
+RC=0
+check_log() {
+    if ! grep -q "$1" $LOG; then
+        echo "$1 not found in log" >&2
+        ((RC=RC+1))
+    fi
+}
+
+check_log "^touch([0-9]*).*includeme$"
+
+if grep -Eq "notme|^dd" $LOG; then
+    echo "notme found in log" >&2
+    ((RC=RC+1))
+fi
+
+if [ $RC -ne 0 ]; then
+   echo "$RC checks failed -- log:" >&2
+   echo "===================" >&2
+   cat $LOG >&2
+   echo "===================" >&2
+fi
+
+exit $RC

--- a/tests/run
+++ b/tests/run
@@ -4,7 +4,7 @@ set -eu
 MYDIR=$(dirname $(readlink -f "$0"))
 export PATH=$(pwd):$PATH
 
-for t in fatrace fatrace-currentmount fatrace-btrfs fatrace-user; do
+for t in fatrace fatrace-currentmount fatrace-btrfs fatrace-user fatrace-comm; do
     export AUTOPKGTEST_TMP=$(mktemp -d)
     echo "===== $t ===="
     "$MYDIR"/$t


### PR DESCRIPTION
/proc/pid/comm is at most 15 characters (plus NUL), so specifying a
longer `--command` value will never match. Truncate it to the maximum
and warn about it.

Note that the manpage speaks about `TASK_COMM_LEN`, but that isn't
defined anywhere. So define it ourselves.

Fixes #33

[1] https://man7.org/linux/man-pages/man5/proc_pid_comm.5.html
