### PR TITLE
Fix test failure count

### DIFF
--- a/tests/fatrace
+++ b/tests/fatrace
@@ -31,7 +31,8 @@ check_log() {
 }
 
 # accessing the "head" binary
-check_log "RC\?O\? \+/usr/bin/head$"
+head="$(which head)"
+check_log "RC\?O\? \+${head}$"
 # head accessing /etc/passwd
 check_log "RC\?O\? \+/etc/passwd$"
 # file creation

--- a/tests/fatrace
+++ b/tests/fatrace
@@ -26,7 +26,7 @@ echo "checking log..."
 check_log() {
     if ! grep -q "$1" $LOG; then
         echo "$1 not found in log" >&2
-        ((RC=RC+1))
+        RC=$((RC+1))
     fi
 }
 

--- a/tests/fatrace-btrfs
+++ b/tests/fatrace-btrfs
@@ -57,7 +57,7 @@ RC=0
 check_log() {
     if ! grep -q "$1" $LOG; then
         echo "$1 not found in log" >&2
-        ((RC=RC+1))
+        RC=$((RC+1))
     fi
 }
 

--- a/tests/fatrace-comm
+++ b/tests/fatrace-comm
@@ -21,7 +21,7 @@ RC=0
 check_log() {
     if ! grep -q "$1" $LOG; then
         echo "$1 not found in log" >&2
-        ((RC=RC+1))
+        RC=$((RC+1))
     fi
 }
 
@@ -29,7 +29,7 @@ check_log "^touch([0-9]*).*includeme$"
 
 if grep -Eq "notme|^dd" $LOG; then
     echo "notme found in log" >&2
-    ((RC=RC+1))
+    RC=$((RC+1))
 fi
 
 # exceeds TASK_COMM_LEN

--- a/tests/fatrace-currentmount
+++ b/tests/fatrace-currentmount
@@ -38,7 +38,7 @@ RC=0
 check_log() {
     if ! grep -q "$1" $LOG; then
         echo "$1 not found in log" >&2
-        ((RC=RC+1))
+        RC=$((RC+1))
     fi
 }
 

--- a/tests/fatrace-user
+++ b/tests/fatrace-user
@@ -37,7 +37,7 @@ RC=0
 check_log() {
     if ! grep -q "$1" $LOG; then
         echo "$1 not found in log" >&2
-        ((RC=RC+1))
+        RC=$((RC+1))
     fi
 }
 

--- a/tests/fatrace-user
+++ b/tests/fatrace-user
@@ -10,7 +10,7 @@ trap "rm -rf tmp" EXIT INT QUIT PIPE
 
 LOG="$AUTOPKGTEST_TMP/fatrace.log"
 echo "starting fatrace..."
-fatrace --current-mount --user -s 2 -o $LOG &
+fatrace --current-mount --user -s 4 -o $LOG &
 sleep 1
 
 echo "read a file as root ..."


### PR DESCRIPTION
- Stop using `((RC=RC+1))` syntax which is a no-op in sh. This caused test scripts to exit with code 0 even after failures.
- Fix `tests/fatrace` test that was broken by commit `8612235 Add option -j,--json`.

Fixes #55