### PR TITLE
Fix null dereference in --command option by checking strdup result

### DIFF
--- a/fatrace.c
+++ b/fatrace.c
@@ -645,6 +645,8 @@ parse_args (int argc, char** argv)
         switch (c) {
             case 'C':
                 option_comm = strdup (optarg);
+                if (!option_comm)
+                    err(EXIT_FAILURE, "memory allocation failed for --command");
                 /* see https://man7.org/linux/man-pages/man5/proc_pid_comm.5.html */
                 if (strlen (option_comm) > TASK_COMM_LEN - 1) {
                     option_comm[TASK_COMM_LEN - 1] = '\0';
@@ -658,6 +660,8 @@ parse_args (int argc, char** argv)
 
             case 'o':
                 option_output = strdup (optarg);
+                if (!option_output)
+                    err(EXIT_FAILURE, "memory allocation failed for --output");
                 break;
 
             case 'u':


### PR DESCRIPTION
### Summary

This patch fixes a potential null pointer dereference caused by a missing NULL check after `strdup()` when processing the `--command` option argument.

Since `strdup(optarg)` may return `NULL` under low-memory conditions, directly passing its result to `strlen()` could lead to a crash.

### Fix

Adds a NULL check immediately after calling `strdup(optarg)`.

If allocation fails, the program prints a descriptive error message and exits safely.

This prevents a potential segmentation fault by validating the pointer before it is used.

### Code

```c
option_comm = strdup(optarg);
if (!option_comm) {
    errx(EXIT_FAILURE, "memory allocation failed for --command");
}
if (strlen(option_comm) > TASK_COMM_LEN - 1) {
    option_comm[TASK_COMM_LEN - 1] = '\0';
    warnx("--command truncated to %i characters: %s", TASK_COMM_LEN - 1, option_comm);
}
